### PR TITLE
build arm32 on amd64 container

### DIFF
--- a/content/dotnet-template-azure-iot-edge-module/CSharp/Dockerfile.arm32v7
+++ b/content/dotnet-template-azure-iot-edge-module/CSharp/Dockerfile.arm32v7
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim-arm32v7 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build-env
 WORKDIR /app
 
 COPY *.csproj ./
-RUN dotnet restore
+RUN dotnet restore -r linux-arm
 
 COPY . ./
 RUN dotnet publish -c Release -o out


### PR DESCRIPTION
Use AMD64 image to build an ARM32 image
(note the -r linux-arm on restore)